### PR TITLE
Remove stale snapshots with old-formatted names #180

### DIFF
--- a/src/main/resources/lib/snapshot-job-scheduler.js
+++ b/src/main/resources/lib/snapshot-job-scheduler.js
@@ -5,7 +5,7 @@ const libs = {
     configParser: require('/lib/config-parser'),
 };
 
-const appName = 'com.enonic.app.snapshotter';
+const appName = app.name;
 const scheduledSnapshotJobPrefix = appName + '--'
 const snapshotTaskDescriptor = appName + ':snapshot';
 const cleanupTaskDescriptor = appName + ':clean';
@@ -14,6 +14,7 @@ exports.list = listScheduledJobs;
 exports.makeScheduledSnapshotJobName = makeScheduledSnapshotJobName;
 exports.scheduleSnapshotsJobs = scheduleSnapshotsJobs;
 exports.disableScheduledJobs = disableScheduledJobs;
+exports.appPrefix = scheduledSnapshotJobPrefix;
 
 function listScheduledJobs() {
     return libs.scheduler.list();

--- a/src/main/resources/lib/snapshotter.js
+++ b/src/main/resources/lib/snapshotter.js
@@ -53,7 +53,7 @@ exports.snapshot = function (params) {
 };
 
 exports.deleteSnapshot = function (params) {
-    bean.deleteSnapshot(required(params, 'scheduleName'), required(params, 'keep'));
+    bean.deleteSnapshot(required(params, 'scheduleName'), required(params, 'keep'), required(params, 'appPrefix'));
 };
 
 exports.getConfig = function () {

--- a/src/main/resources/tasks/clean/clean.js
+++ b/src/main/resources/tasks/clean/clean.js
@@ -26,6 +26,7 @@ function cleanScheduledJob(schedule) {
 
     libs.snapshotter.deleteSnapshot({
         scheduleName: jobName,
+        appPrefix: libs.snapshotJobScheduler.appPrefix,
         keep: schedule.keep
     });
 }

--- a/src/test/java/com/enonic/app/snapshotter/handler/SnapshotterHandlerTest.java
+++ b/src/test/java/com/enonic/app/snapshotter/handler/SnapshotterHandlerTest.java
@@ -6,6 +6,8 @@ import java.time.temporal.ChronoUnit;
 import org.junit.Assert;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mockito;
 
 import com.enonic.xp.node.DeleteSnapshotParams;
@@ -15,6 +17,7 @@ import com.enonic.xp.node.SnapshotResult;
 import com.enonic.xp.node.SnapshotResults;
 import com.enonic.xp.snapshot.SnapshotService;
 import com.enonic.xp.testing.ScriptTestSupport;
+
 
 public class SnapshotterHandlerTest
     extends ScriptTestSupport
@@ -35,9 +38,7 @@ public class SnapshotterHandlerTest
     @Test
     public void testSnapshot()
     {
-        final SnapshotResult snapshotResult = SnapshotResult.create().
-            state( SnapshotResult.State.SUCCESS ).
-            build();
+        final SnapshotResult snapshotResult = SnapshotResult.create().state( SnapshotResult.State.SUCCESS ).build();
 
         Mockito.when( snapshotService.snapshot( Mockito.any( SnapshotParams.class ) ) ).thenReturn( snapshotResult );
 
@@ -49,24 +50,27 @@ public class SnapshotterHandlerTest
     @Test
     public void testDeleteSnapshot()
     {
-        final SnapshotResults snapshots = SnapshotResults.create().
-            add( SnapshotResult.create().
-                name( "name" ).
-                timestamp( Instant.now().minus( 2, ChronoUnit.HOURS ) ).
-                build() ).
-            build();
+        final String snapshotName = "com.enonic.app.snapshotter--name_2020-01-01T00-00-00.000z";
+        final String snapshotNameOldFormat = "name_2020-01-01T00-00-00.000z";
+        final String snapshotWithOtherName = "com.enonic.app.snapshotter--nameother_2020-01-01T00-00-00.000z";
+        final SnapshotResults snapshots = SnapshotResults.create()
+            .add( SnapshotResult.create().name( snapshotName ).timestamp( Instant.now().minus( 2, ChronoUnit.HOURS ) ).build() )
+            .add( SnapshotResult.create().name( snapshotNameOldFormat ).timestamp( Instant.now().minus( 2, ChronoUnit.HOURS ) ).build() )
+            .add( SnapshotResult.create().name( snapshotWithOtherName ).timestamp( Instant.now().minus( 2, ChronoUnit.HOURS ) ).build() )
+            .build();
 
-        final DeleteSnapshotsResult deleteSnapshotsResult = DeleteSnapshotsResult.create().
-            add( "name" ).
-            build();
+        final DeleteSnapshotsResult deleteSnapshotsResult = DeleteSnapshotsResult.create().add( snapshotName ).add( snapshotNameOldFormat ).build();
 
         Mockito.when( snapshotService.list() ).thenReturn( snapshots );
         Mockito.when( snapshotService.delete( Mockito.any( DeleteSnapshotParams.class ) ) ).thenReturn( deleteSnapshotsResult );
 
         runFunction( "test/SnapshotterHandlerTest.js", "deleteSnapshot" );
 
+        final ArgumentCaptor<DeleteSnapshotParams> captor = ArgumentCaptor.forClass( DeleteSnapshotParams.class );
+
         Mockito.verify( snapshotService, Mockito.times( 1 ) ).list();
-        Mockito.verify( snapshotService, Mockito.times( 1 ) ).delete( Mockito.any( DeleteSnapshotParams.class ) );
+        Mockito.verify( snapshotService, Mockito.times( 1 ) ).delete( captor.capture() );
+        assertEquals( captor.getValue().getSnapshotNames().size(), 2 );
     }
 
     @Test

--- a/src/test/resources/test/SnapshotterHandlerTest.js
+++ b/src/test/resources/test/SnapshotterHandlerTest.js
@@ -25,7 +25,8 @@ exports.snapshot = function () {
 
 exports.deleteSnapshot = function () {
     snapshotter.deleteSnapshot({
-        scheduleName: 'name',
+        scheduleName: 'com.enonic.app.snapshotter--name',
+        appPrefix: 'com.enonic.app.snapshotter--',
         keep: 'PT1H'
     });
 };


### PR DESCRIPTION
- Old format didn't have app prefix, fixed by adding prefix parameter to delete method
- Adjusted filtering of snapshots for delete: a) Checking also snapshot with old format name
b) Adding '_' separator to the schedule name when filtering to avoid deleting wrong snapshots that may start with the same name, like "abra" and "abrakadabra"