### PR TITLE
Adjust default cleanup schedule #182

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Three schedules (hourly, daily and weekly) are configured by default:
     snapshot.weekly.keep=P30D
     snapshot.weekly.enabled=true
 
-    cleanup.cron=0 * * * *
+    cleanup.cron=*/30 * * * *
 
   
 The ``cron``-property is a string in Unix cron format (http://www.nncron.ru/help/EN/working/cron-format.htm)

--- a/com.enonic.app.snapshotter.cfg
+++ b/com.enonic.app.snapshotter.cfg
@@ -14,7 +14,7 @@ snapshot.weekly.keep=P30D
 snapshot.weekly.enabled=true
 snapshot.weekly.timezone=UTC
 
-cleanup.cron=0 * * * *
+cleanup.cron=*/30 * * * *
 cleanup.timezone=UTC
 
 ## You can add new named schedules if needed

--- a/src/main/resources/lib/snapshotter.js
+++ b/src/main/resources/lib/snapshotter.js
@@ -15,7 +15,7 @@ var defaultConfig = {
     "snapshot.weekly.keep": "P30D",
     "snapshot.weekly.enabled": "true",
 
-    "cleanup.cron": "0 * * * *"
+    "cleanup.cron": "*/30 * * * *"
 };
 
 function required(params, name) {

--- a/src/test/resources/test/SnapshotterHandlerTest.js
+++ b/src/test/resources/test/SnapshotterHandlerTest.js
@@ -11,7 +11,7 @@ var expectedDefaultConfig = {
     "snapshot.weekly.cron": "0 4 * * 1",
     "snapshot.weekly.keep": "P30D",
     "snapshot.weekly.enabled": "true",
-    "cleanup.cron": "0 * * * *"
+    "cleanup.cron": "*/30 * * * *"
 };
 
 exports.snapshot = function () {

--- a/src/test/resources/test/config-parser-test.js
+++ b/src/test/resources/test/config-parser-test.js
@@ -13,7 +13,7 @@ var appConfig = {
     "snapshot.weekly.keep": "P30D",
     "snapshot.weekly.enabled": "true",
 
-    "cleanup.cron": "0 * * * *",
+    "cleanup.cron": "*/30 * * * *",
 
     "notifier.slack.slackWebhook": "slackWebhookUrl",
     "notifier.slack.project": "Snapshotter",
@@ -77,7 +77,7 @@ var expectedNotifiersConfig = [
 ];
 
 var expectedCleanupCron = {
-    "cron": "0 * * * *",
+    "cron": "*/30 * * * *",
     "timezone": "UTC"
 };
 


### PR DESCRIPTION
- Setting cleanup to be run every 30th minute instead of every 0th minute of an hour to avoid elastic concurrency issues, triggered when snapshots are deleted and created simultaneously