### PR TITLE
Allow setting up timezone #184

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,18 @@ To disable a default schedule, just set `enabled` to `false`, e.g ``snapshot.hou
 
 The cleanup schedule is configured to run every hour by default. This will delete snapshots that are outside the keep-range of the schedules. This schedule can be changed via ``cleanup.cron`` setting
 
+### Time Zone
+
+All the schedules are using UTC timezone by default, however you can change it by adding 'timezone' property in the config file:
+
+    snapshot.snapshotname.timezone=GMT+07:00
+
+or
+
+    cleanup.timezone=Europe/Oslo
+
+
+
 ### Notifiers
 
 #### Slack

--- a/com.enonic.app.snapshotter.cfg
+++ b/com.enonic.app.snapshotter.cfg
@@ -2,16 +2,20 @@
 snapshot.hourly.cron=1 * * * *
 snapshot.hourly.keep=PT48H
 snapshot.hourly.enabled=true
+snapshot.hourly.timezone=UTC
 
 snapshot.daily.cron=0 1 * * *
 snapshot.daily.keep=P7D
 snapshot.daily.enabled=true
+snapshot.daily.timezone=UTC
 
 snapshot.weekly.cron=0 4 * * 1
 snapshot.weekly.keep=P30D
 snapshot.weekly.enabled=true
+snapshot.weekly.timezone=UTC
 
 cleanup.cron=0 * * * *
+cleanup.timezone=UTC
 
 ## You can add new named schedules if needed
 

--- a/src/main/resources/lib/config-parser.js
+++ b/src/main/resources/lib/config-parser.js
@@ -35,6 +35,7 @@ function SnapshotterConfigParser(config) {
                 name: snapshotJobName,
                 keep: self.getProperty(snapshotConfigs, snapshotJobName, "keep"),
                 cron: self.getProperty(snapshotConfigs, snapshotJobName, "cron"),
+                timezone: self.getProperty(snapshotConfigs, snapshotJobName, "timezone", "UTC"),
                 enabled: self.getBooleanProperty(snapshotConfigs, snapshotJobName, "enabled"),
             });
         });
@@ -89,13 +90,20 @@ function SnapshotterConfigParser(config) {
     };
 
     this.parseCleanupCron = function () {
-        return this.getProperty(config, "cleanup", "cron");
+        return {
+            cron: this.getProperty(config, "cleanup", "cron"),
+            timezone: this.getProperty(config, "cleanup", "timezone", "UTC"),
+        };
     };
 
-    this.getProperty = function (configs, name, propName) {
+    this.getProperty = function (configs, name, propName, defaultValue) {
         var property = name + '.' + propName;
 
         if (!configs.hasOwnProperty(property)) {
+            if (defaultValue !== undefined) {
+                return defaultValue
+            }
+
             throw new Error("Missing property: [" + property + "]");
         }
 

--- a/src/main/resources/lib/snapshot-job-scheduler.js
+++ b/src/main/resources/lib/snapshot-job-scheduler.js
@@ -53,7 +53,7 @@ function createScheduledJob(params) {
         schedule: {
             type: 'CRON',
             value: params.cron,
-            timeZone: 'UTC',
+            timeZone: params.timezone,
         },
     };
 
@@ -71,7 +71,7 @@ function updateScheduledJob(params) {
             edit.schedule = {
                 type: 'CRON',
                 value: params.cron,
-                timeZone: 'UTC',
+                timeZone: params.timezone,
             };
             edit.enabled = params.enabled;
 
@@ -96,6 +96,7 @@ function scheduleSnapshots(snapshotsConfigs) {
             name: snapshotConfig.name,
             taskDescriptor: snapshotTaskDescriptor,
             cron: snapshotConfig.cron,
+            timezone: snapshotConfig.timezone,
             enabled: snapshotConfig.enabled,
             config: {
                 name: snapshotConfig.name
@@ -115,13 +116,15 @@ function getSnapshotsToSchedule(appConfig) {
 }
 
 function scheduleCleanup(appConfig) {
-    const cleanupCron = libs.configParser.parseCleanupCron(appConfig);
+    const params = libs.configParser.parseCleanupCron(appConfig);
+    log.info('Scheduling cleanup with cron: ' + JSON.stringify(params));
     const cleanupCronName = makeCleanupCronName();
 
     scheduleJob({
         name: cleanupCronName,
         taskDescriptor: cleanupTaskDescriptor,
-        cron: cleanupCron,
+        cron: params.cron,
+        timezone: params.timezone,
         enabled: true,
     });
 }

--- a/src/test/resources/test/config-parser-test.js
+++ b/src/test/resources/test/config-parser-test.js
@@ -5,6 +5,7 @@ var appConfig = {
     "snapshot.hourly.cron": "1 * * * *",
     "snapshot.hourly.keep": "PT48H",
     "snapshot.hourly.enabled": "true",
+    "snapshot.hourly.timezone": "GMT+02:00",
     "snapshot.daily.cron": "0 1 * * *",
     "snapshot.daily.keep": "P7D",
     "snapshot.daily.enabled": "true",
@@ -30,18 +31,21 @@ var expectedSnapshotConfig = [
         "name": "hourly",
         "keep": "PT48H",
         "cron": "1 * * * *",
+        "timezone": "GMT+02:00",
         "enabled": true
     },
     {
         "name": "daily",
         "keep": "P7D",
         "cron": "0 1 * * *",
+        "timezone": "UTC",
         "enabled": true
     },
     {
         "name": "weekly",
         "keep": "P30D",
         "cron": "0 4 * * 1",
+        "timezone": "UTC",
         "enabled": true
     }
 ];
@@ -72,7 +76,10 @@ var expectedNotifiersConfig = [
     }
 ];
 
-var expectedCleanupCron = "0 * * * *";
+var expectedCleanupCron = {
+    "cron": "0 * * * *",
+    "timezone": "UTC"
+};
 
 exports.testParseSnapshots = function () {
     t.assertJsonEquals(expectedSnapshotConfig, parser.parseSnapshots(appConfig));


### PR DESCRIPTION
- Now 'timezone' property is available for scheduled jobs so precise GMT zone can be set, e.g. 'snapshot.snapshotname.timezone=GMT+02:00'. UTC timezone is used by default.