### PR TITLE
Allow asset API in admin tool #246

### DIFF
--- a/src/main/resources/admin/tools/snapshotter/snapshotter.yaml
+++ b/src/main/resources/admin/tools/snapshotter/snapshotter.yaml
@@ -4,4 +4,5 @@ description: "Scheduled snapshotting"
 allow:
 - "role:system.admin"
 apis:
+- "asset"
 - "notifier-test-service"


### PR DESCRIPTION
## Summary

The Snapshotter admin tool's `snapshotter.yaml` only whitelisted the `notifier-test-service` API. On XP 8 (where bundled `lib-asset` registers itself as the `asset` API on the host app), the admin tool's CSS and JS assets were being rejected by the API mount registry with `API [com.enonic.app.snapshotter:asset] is not mounted` — so `/admin/com.enonic.app.snapshotter/snapshotter` rendered the HTML structure but with no styling and no client JS.

Adding `"asset"` to the tool's `apis:` list lets `/_/<app>:asset/...` URLs (built by `lib/enonic/asset` `assetUrl(...)`) resolve under the admin tool. The system apps (`app-applications/admin/tools/main/main.yaml`) follow the same pattern.

## Test plan

- [x] Build `xp-distro` at `8.0.0-SNAPSHOT`, deploy `snapshotter.jar` into `home/deploy/`
- [x] Verify bundle reaches ACTIVE in `server.log` (`Started application com.enonic.app.snapshotter bundle …`)
- [x] Hit `/admin/com.enonic.app.snapshotter/snapshotter` after logging in as `su` — page renders, lists `hourly` / `daily` / `weekly` schedules
- [x] Hit one CSS asset URL emitted by the page — was `404 {"status":404,"message":"API [com.enonic.app.snapshotter:asset] is not mounted"}`, now `200 text/css`
- [x] Hit `snapshotter.js` asset URL — was `404`, now `200 application/javascript`

Closes #246

🤖 Generated with [Claude Code](https://claude.com/claude-code)