### PR TITLE
Introduce TOML version catalog

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -15,17 +15,17 @@ dependencies {
     include "com.enonic.xp:lib-cluster:${xpVersion}"
     include "com.enonic.xp:lib-mail:${xpVersion}"
     include "com.enonic.xp:lib-scheduler:${xpVersion}"
-    include "com.enonic.lib:lib-http-client:4.0.0-SNAPSHOT"
-    include "com.enonic.lib:lib-mustache:2.1.1"
-    include "com.enonic.lib:lib-asset:2.0.0-SNAPSHOT"
-    include "com.fasterxml.jackson.jr:jackson-jr-objects:2.21.3"
+    include libs.lib.http.client
+    include libs.lib.mustache
+    include libs.lib.asset
+    include libs.jackson.jr.objects
 
     testImplementation "com.enonic.xp:testing:${xpVersion}"
-    testImplementation( platform( "org.junit:junit-bom:6.0.3" ) )
-    testImplementation( platform( "org.mockito:mockito-bom:5.23.0" ) )
-    testImplementation 'org.junit.jupiter:junit-jupiter'
-    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
-    testImplementation 'org.mockito:mockito-junit-jupiter'
+    testImplementation( platform( libs.junit.bom ) )
+    testImplementation( platform( libs.mockito.bom ) )
+    testImplementation libs.junit.jupiter
+    testRuntimeOnly libs.junit.platform.launcher
+    testImplementation libs.mockito.junit.jupiter
 }
 
 repositories {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,18 @@
+[versions]
+asset = "2.0.0-SNAPSHOT"
+http-client = "4.0.0-SNAPSHOT"
+jackson-jr = "2.21.3"
+junit = "6.0.3"
+mockito = "5.23.0"
+mustache = "2.1.1"
+
+[libraries]
+jackson-jr-objects = { module = "com.fasterxml.jackson.jr:jackson-jr-objects", version.ref = "jackson-jr" }
+junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
+junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
+junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
+lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
+lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
+lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
+mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
+mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }


### PR DESCRIPTION
## Summary

Move inline dependency versions from `build.gradle` into a `gradle/libs.versions.toml` catalog. Pin-for-pin migration: no versions changed, and the resolved `runtimeClasspath` / `testRuntimeClasspath` dependency trees are identical to pre-migration.

This is part of a broader sweep to unify the version-management style across the IdeaProjects tree so bulk dep bumps (XP 8 SNAPSHOTs, etc.) take a single sed run.

## Conventions adopted

- `[versions]` and `[libraries]` sorted alphabetically
- Lowercase, hyphen-separated keys
- Library keys retain a `lib-` prefix when the artifact name starts with `lib-`
- `xpVersion` stays in `gradle.properties` (all `com.enonic.xp:*:\${xpVersion}` lines untouched)
- `xplibs.*` accessors untouched

## Catalog

\`\`\`toml
[versions]
asset = "2.0.0-SNAPSHOT"
http-client = "4.0.0-SNAPSHOT"
jackson-jr = "2.21.3"
junit = "6.0.3"
mockito = "5.23.0"
mustache = "2.1.1"

[libraries]
jackson-jr-objects = { module = "com.fasterxml.jackson.jr:jackson-jr-objects", version.ref = "jackson-jr" }
junit-bom = { module = "org.junit:junit-bom", version.ref = "junit" }
junit-jupiter = { module = "org.junit.jupiter:junit-jupiter" }
junit-platform-launcher = { module = "org.junit.platform:junit-platform-launcher" }
lib-asset = { module = "com.enonic.lib:lib-asset", version.ref = "asset" }
lib-http-client = { module = "com.enonic.lib:lib-http-client", version.ref = "http-client" }
lib-mustache = { module = "com.enonic.lib:lib-mustache", version.ref = "mustache" }
mockito-bom = { module = "org.mockito:mockito-bom", version.ref = "mockito" }
mockito-junit-jupiter = { module = "org.mockito:mockito-junit-jupiter" }
\`\`\`

## Test plan

- [x] \`./gradlew build --refresh-dependencies\` passes locally
- [x] \`./gradlew dependencies --configuration runtimeClasspath\` identical before/after
- [x] \`./gradlew dependencies --configuration testRuntimeClasspath\` identical before/after